### PR TITLE
fix(security): tweak strict SRI regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const SPEC_ALGORITHMS = ['sha256', 'sha384', 'sha512']
 
 const BASE64_REGEX = /^[a-z0-9+/]+(?:=?=?)$/i
 const SRI_REGEX = /^([^-]+)-([^?]+)([?\S*]*)$/
-const STRICT_SRI_REGEX = /^([^-]+)-([A-Za-z0-9+/]+(?:=?=?))([?\x21-\x7E]*)$/
+const STRICT_SRI_REGEX = /^([^-]+)-([A-Za-z0-9+/=]{44,88})(\?[\x21-\x7E]*)*$/
 const VCHAR_REGEX = /^[\x21-\x7E]+$/
 
 class Hash {

--- a/test/integrity.js
+++ b/test/integrity.js
@@ -7,20 +7,20 @@ const test = require('tap').test
 const ssri = require('..')
 
 test('toString()', t => {
-  const sri = ssri.parse('sha512-foo sha256-bar!')
+  const sri = ssri.parse('sha1-eUN/Xt2hP5wGabl43XqQZt0gWfE= sha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=')
   t.equal(
     sri.toString(),
-    'sha512-foo sha256-bar!',
+    'sha1-eUN/Xt2hP5wGabl43XqQZt0gWfE= sha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=',
     'integrity objects from ssri.parse() can use toString()'
   )
   t.equal(
     sri.toString({strict: true}),
-    'sha512-foo',
+    'sha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=',
     'accepts strict mode option'
   )
   t.equal(
     sri.toString({sep: '\n'}),
-    'sha512-foo\nsha256-bar!',
+    'sha1-eUN/Xt2hP5wGabl43XqQZt0gWfE=\nsha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=',
     'accepts separator option'
   )
   t.done()
@@ -72,9 +72,12 @@ test('concat()', t => {
     'sha512-foo sha512-quux sha1-bar sha1-baz',
     'preserves relative order for algorithms between different concatenations'
   )
+  const strictSri = ssri.parse('sha512-WrLorGiX4iEWOOOaJSiCrmDIamA47exH+Bz7tVwIPb4sCU8w4iNqGCqYuspMMeU5pgz/sU7koP5u8W3RCUojGw==')
   t.equal(
-    sri.concat('sha1-bar!', {strict: true}).toString(),
-    'sha512-foo',
+    strictSri.concat('sha1-eUN/Xt2hP5wGabl43XqQZt0gWfE=', {
+      strict: true
+    }).toString(),
+    'sha512-WrLorGiX4iEWOOOaJSiCrmDIamA47exH+Bz7tVwIPb4sCU8w4iNqGCqYuspMMeU5pgz/sU7koP5u8W3RCUojGw==',
     'accepts strict mode option'
   )
   t.done()

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -108,8 +108,8 @@ test('support strict serialization', t => {
     'entries that do not conform to strict spec interpretation removed'
   )
   t.equal(
-    ssri.stringify('sha512-foo sha256-bar', {sep: ' \r|\n\t', strict: true}),
-    'sha512-foo \r \n\tsha256-bar',
+    ssri.stringify('sha512-WrLorGiX4iEWOOOaJSiCrmDIamA47exH+Bz7tVwIPb4sCU8w4iNqGCqYuspMMeU5pgz/sU7koP5u8W3RCUojGw== sha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=', {sep: ' \r|\n\t', strict: true}),
+    'sha512-WrLorGiX4iEWOOOaJSiCrmDIamA47exH+Bz7tVwIPb4sCU8w4iNqGCqYuspMMeU5pgz/sU7koP5u8W3RCUojGw== \r \n\tsha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=',
     'strict mode replaces non-whitespace characters in separator with space'
   )
   t.done()


### PR DESCRIPTION
The previous form was vulnerable to ReDoS attacks, by
crafting exceptionally long base64 hash strings.

This issue only affected consumers using the opts.strict option.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
